### PR TITLE
fix(dependabot): group each ecosystem into one PR (range deps weren't grouping)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,16 +1,20 @@
 # Dependabot version updates
 # https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 #
-# Policy for this repo (mirrors the gearbox repo, improved):
+# Policy for this repo (mirrors the gearbox repo):
 #   - Monthly cadence on every ecosystem. Weekly produced a flood of single-dep
 #     PRs that were impossible to keep up with.
-#   - Everything is GROUPED so each ecosystem opens at most two PRs per run:
-#       <ecosystem>-minor-patch  -> auto-merged by dependabot-auto-merge.yml
-#       <ecosystem>-major        -> held for manual review (commented, not merged)
-#     Splitting minor/patch from major matters: a group's update-type is the
-#     highest member, so bundling a major in with patches would block the whole
-#     group from auto-merging. Keeping them separate lets the safe stuff sail
-#     through while majors wait for a human.
+#   - ONE group per ecosystem (patterns: ["*"], no update-types filter) so each
+#     ecosystem opens a single PR per run.
+#       * Do NOT split into minor-patch vs major via `update-types`: that filter
+#         relies on semver classification, which Dependabot cannot compute for
+#         version-RANGE requirements (e.g. pip deps in pyproject.toml like
+#         "<1.0,>=0.9"). Range updates then match no group and fall out to
+#         individual PRs — the exact flood this config is meant to prevent.
+#         A single group sidesteps that and bundles everything.
+#   - dependabot-auto-merge.yml auto-merges a grouped PR only when its overall
+#     update-type is patch/minor; a group that includes a major bump is held
+#     for manual review (commented, not merged).
 #   - Consistent labels + Conventional-Commit prefix so PRs are easy to triage.
 #
 # NOTE: Dependabot does not support YAML anchors or custom top-level keys, so the
@@ -26,17 +30,12 @@ updates:
     open-pull-requests-limit: 5
     commit-message:
       prefix: "chore(deps)"
-      include: scope
     labels:
       - dependencies
       - github_actions
     groups:
-      github-actions-minor-patch:
+      github-actions:
         patterns: ["*"]
-        update-types: ["minor", "patch"]
-      github-actions-major:
-        patterns: ["*"]
-        update-types: ["major"]
 
   - package-ecosystem: docker
     directory: /
@@ -46,17 +45,12 @@ updates:
     open-pull-requests-limit: 5
     commit-message:
       prefix: "chore(deps)"
-      include: scope
     labels:
       - dependencies
       - docker
     groups:
-      docker-minor-patch:
+      docker:
         patterns: ["*"]
-        update-types: ["minor", "patch"]
-      docker-major:
-        patterns: ["*"]
-        update-types: ["major"]
 
   - package-ecosystem: npm
     directory: /
@@ -66,17 +60,12 @@ updates:
     open-pull-requests-limit: 5
     commit-message:
       prefix: "chore(deps)"
-      include: scope
     labels:
       - dependencies
       - javascript
     groups:
-      npm-minor-patch:
+      npm:
         patterns: ["*"]
-        update-types: ["minor", "patch"]
-      npm-major:
-        patterns: ["*"]
-        update-types: ["major"]
 
   - package-ecosystem: pip
     directory: /
@@ -86,14 +75,9 @@ updates:
     open-pull-requests-limit: 5
     commit-message:
       prefix: "chore(deps)"
-      include: scope
     labels:
       - dependencies
       - python
     groups:
-      pip-minor-patch:
+      pip:
         patterns: ["*"]
-        update-types: ["minor", "patch"]
-      pip-major:
-        patterns: ["*"]
-        update-types: ["major"]

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -14,6 +14,23 @@ on:
     branches: ["main"]
   pull_request:
     branches: ["main"]
+    # Only rebuild + scan the image when something that affects it changes.
+    # Skips doc/config-only PRs (e.g. dependabot.yml) — no point rebuilding
+    # 700+ MB to scan a YAML edit. Mirrors container-test.yml's filter.
+    paths:
+      - "home/**"
+      - "scripts/**"
+      - "usr/**"
+      - "workflow_scripts/**"
+      - ".dockerignore"
+      - ".mise.toml"
+      - ".pre-commit-config.yaml"
+      - "Dockerfile"
+      - "requirements.txt"
+      - "pyproject.toml"
+      - "package.json"
+      - "**/*.sh"
+      - ".github/workflows/trivy.yml"
   schedule:
     - cron: "19 14 * * 5"
   workflow_dispatch: # Allows manual triggering


### PR DESCRIPTION
## Problem

After #171, pip updates still opened one PR per dependency (#172–#177: ruff, requests, click, pydantic, mypy) instead of a single grouped PR.

## Cause

The config split each ecosystem into `*-minor-patch` and `*-major` groups via `update-types`. That filter relies on semver classification, which Dependabot **can't compute for version-range requirements** (pip deps in `pyproject.toml` like `<1.0,>=0.9`). Range-widening updates matched neither group → individual PRs. (GitHub Actions, which use pinned versions, grouped fine — hence the asymmetry.)

## Fix

One plain group per ecosystem (`patterns: ["*"]`, no `update-types`) — gearbox's original pattern — so everything bundles into a single PR. Also dropped `commit-message.include: scope`, which produced the doubled `chore(deps)(deps)` prefix.

`dependabot-auto-merge.yml` still holds any grouped PR whose overall update-type is major.

After merge, Dependabot re-evaluates and will supersede the individual pip PRs with one grouped PR.